### PR TITLE
Add compatibility with ES6 modules

### DIFF
--- a/src/ReactDOMServer.res
+++ b/src/ReactDOMServer.res
@@ -1,5 +1,5 @@
-@module("react-dom/server")
+@module("react-dom/server.js")
 external renderToString: React.element => string = "renderToString"
 
-@module("react-dom/server")
+@module("react-dom/server.js")
 external renderToStaticMarkup: React.element => string = "renderToStaticMarkup"

--- a/src/ReactTestUtils.res
+++ b/src/ReactTestUtils.res
@@ -2,7 +2,7 @@ type undefined = Js.undefined<unit>
 
 let undefined: undefined = Js.Undefined.empty
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external reactAct: ((. unit) => undefined) => unit = "act"
 
 let act: (unit => unit) => unit = func => {
@@ -13,7 +13,7 @@ let act: (unit => unit) => unit = func => {
   reactAct(reactFunc)
 }
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external reactActAsync: ((. unit) => Js.Promise.t<'a>) => Js.Promise.t<unit> = "act"
 
 let actAsync = func => {
@@ -21,32 +21,32 @@ let actAsync = func => {
   reactActAsync(reactFunc)
 }
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external isElement: 'element => bool = "isElement"
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external isElementOfType: ('element, React.component<'props>) => bool = "isElementOfType"
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external isDOMComponent: 'element => bool = "isDOMComponent"
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external isCompositeComponent: 'element => bool = "isCompositeComponent"
 
-@module("react-dom/test-utils")
+@module("react-dom/test-utils.js")
 external isCompositeComponentWithType: ('element, React.component<'props>) => bool =
   "isCompositeComponentWithType"
 
 module Simulate = {
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external click: Dom.element => unit = "click"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external clickWithEvent: (Dom.element, 'event) => unit = "click"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external change: Dom.element => unit = "change"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external blur: Dom.element => unit = "blur"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external changeWithEvent: (Dom.element, 'event) => unit = "change"
   let changeWithValue = (element, value) => {
     let event = {
@@ -64,13 +64,13 @@ module Simulate = {
     }
     changeWithEvent(element, event)
   }
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external canPlay: Dom.element => unit = "canPlay"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external timeUpdate: Dom.element => unit = "timeUpdate"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external ended: Dom.element => unit = "ended"
-  @module("react-dom/test-utils") @scope("Simulate")
+  @module("react-dom/test-utils.js") @scope("Simulate")
   external focus: Dom.element => unit = "focus"
 }
 

--- a/src/ReactTestUtils.resi
+++ b/src/ReactTestUtils.resi
@@ -2,42 +2,42 @@ let act: (unit => unit) => unit
 
 let actAsync: (unit => Js.Promise.t<'a>) => Js.Promise.t<unit>
 
-@bs.module("react-dom/test-utils")
+@bs.module("react-dom/test-utils.js")
 external isElement: 'element => bool = "isElement"
 
-@bs.module("react-dom/test-utils")
+@bs.module("react-dom/test-utils.js")
 external isElementOfType: ('element, React.component<'props>) => bool = "isElementOfType"
 
-@bs.module("react-dom/test-utils")
+@bs.module("react-dom/test-utils.js")
 external isDOMComponent: 'element => bool = "isDOMComponent"
 
-@bs.module("react-dom/test-utils")
+@bs.module("react-dom/test-utils.js")
 external isCompositeComponent: 'element => bool = "isCompositeComponent"
 
-@bs.module("react-dom/test-utils")
+@bs.module("react-dom/test-utils.js")
 external isCompositeComponentWithType: ('element, React.component<'props>) => bool =
   "isCompositeComponentWithType"
 
 module Simulate: {
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external click: Dom.element => unit = "click"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external clickWithEvent: (Dom.element, 'event) => unit = "click"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external change: Dom.element => unit = "change"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external blur: Dom.element => unit = "blur"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external changeWithEvent: (Dom.element, 'event) => unit = "change"
   let changeWithValue: (Dom.element, string) => unit
   let changeWithChecked: (Dom.element, bool) => unit
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external canPlay: Dom.element => unit = "canPlay"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external timeUpdate: Dom.element => unit = "timeUpdate"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external ended: Dom.element => unit = "ended"
-  @bs.module("react-dom/test-utils") @bs.scope("Simulate")
+  @bs.module("react-dom/test-utils.js") @bs.scope("Simulate")
   external focus: Dom.element => unit = "focus"
 }
 


### PR DESCRIPTION
NodeJS stops supported automatic appending of ".js" when using ES
modules. This PR makes it work in both ESM/CJS by putting it
explicitely.