### PR TITLE
Add data-testid to ReactDOM props

### DIFF
--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -168,6 +168,8 @@ module Props = {
     contentEditable: bool,
     @optional
     contextMenu: string,
+    @optional @as("data-testid")
+    dataTestId: string,
     @optional
     dir: string /* "ltr", "rtl" or "auto" */,
     @optional
@@ -1193,6 +1195,8 @@ module Props = {
     contentEditable: bool,
     @optional
     contextMenu: string,
+    @optional @as("data-testid")
+    dataTestId: string,
     @optional
     dir: string /* "ltr", "rtl" or "auto" */,
     @optional


### PR DESCRIPTION
Adding `dataTestId` to ReactDOM props to allow developers to define test id without the need to create a custom component to prop spread the attribute. 
I picked the default value used by [@testing-libarary](https://testing-library.com/docs/queries/bytestid#overriding-data-testid)