### PR TITLE
Add React 17 & 18 as compatible in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "rescript": "^9.1.4"
   },
   "peerDependencies": {
-    "react": ">=16.8.1",
-    "react-dom": ">=16.8.1"
+    "react": ">=16.8.1 || ^17.0.0 || ^18.0.0",
+    "react-dom": ">=16.8.1 || ^17.0.0 || ^18.0.0"
   },
   "jest": {
     "moduleDirectories": [


### PR DESCRIPTION
Currently even if there is a WIP for full React 18 support in #35, the package is compatible with this version range.
Not having this can be a pain with "recent" version of npm (7+, which is out for a while now).
Could we have this released as a fix? Thanks!