### PR TITLE
Fixed bindings that end with *.js

### DIFF
--- a/src/ReactDOMServer.res
+++ b/src/ReactDOMServer.res
@@ -1,5 +1,5 @@
-@module("react-dom/server.js")
+@module("react-dom/server")
 external renderToString: React.element => string = "renderToString"
 
-@module("react-dom/server.js")
+@module("react-dom/server")
 external renderToStaticMarkup: React.element => string = "renderToStaticMarkup"

--- a/src/ReactTestUtils.res
+++ b/src/ReactTestUtils.res
@@ -2,7 +2,7 @@ type undefined = Js.undefined<unit>
 
 let undefined: undefined = Js.Undefined.empty
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external reactAct: ((. unit) => undefined) => unit = "act"
 
 let act: (unit => unit) => unit = func => {
@@ -13,7 +13,7 @@ let act: (unit => unit) => unit = func => {
   reactAct(reactFunc)
 }
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external reactActAsync: ((. unit) => Js.Promise.t<'a>) => Js.Promise.t<unit> = "act"
 
 let actAsync = func => {
@@ -21,32 +21,32 @@ let actAsync = func => {
   reactActAsync(reactFunc)
 }
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isElement: 'element => bool = "isElement"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isElementOfType: ('element, React.component<'props>) => bool = "isElementOfType"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isDOMComponent: 'element => bool = "isDOMComponent"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isCompositeComponent: 'element => bool = "isCompositeComponent"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isCompositeComponentWithType: ('element, React.component<'props>) => bool =
   "isCompositeComponentWithType"
 
 module Simulate = {
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external click: Dom.element => unit = "click"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external clickWithEvent: (Dom.element, 'event) => unit = "click"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external change: Dom.element => unit = "change"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external blur: Dom.element => unit = "blur"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external changeWithEvent: (Dom.element, 'event) => unit = "change"
   let changeWithValue = (element, value) => {
     let event = {
@@ -64,13 +64,13 @@ module Simulate = {
     }
     changeWithEvent(element, event)
   }
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external canPlay: Dom.element => unit = "canPlay"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external timeUpdate: Dom.element => unit = "timeUpdate"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external ended: Dom.element => unit = "ended"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external focus: Dom.element => unit = "focus"
 }
 

--- a/src/ReactTestUtils.resi
+++ b/src/ReactTestUtils.resi
@@ -2,42 +2,42 @@ let act: (unit => unit) => unit
 
 let actAsync: (unit => Js.Promise.t<'a>) => Js.Promise.t<unit>
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isElement: 'element => bool = "isElement"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isElementOfType: ('element, React.component<'props>) => bool = "isElementOfType"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isDOMComponent: 'element => bool = "isDOMComponent"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isCompositeComponent: 'element => bool = "isCompositeComponent"
 
-@module("react-dom/test-utils.js")
+@module("react-dom/test-utils")
 external isCompositeComponentWithType: ('element, React.component<'props>) => bool =
   "isCompositeComponentWithType"
 
 module Simulate: {
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external click: Dom.element => unit = "click"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external clickWithEvent: (Dom.element, 'event) => unit = "click"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external change: Dom.element => unit = "change"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external blur: Dom.element => unit = "blur"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external changeWithEvent: (Dom.element, 'event) => unit = "change"
   let changeWithValue: (Dom.element, string) => unit
   let changeWithChecked: (Dom.element, bool) => unit
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external canPlay: Dom.element => unit = "canPlay"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external timeUpdate: Dom.element => unit = "timeUpdate"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external ended: Dom.element => unit = "ended"
-  @module("react-dom/test-utils.js") @scope("Simulate")
+  @module("react-dom/test-utils") @scope("Simulate")
   external focus: Dom.element => unit = "focus"
 }
 


### PR DESCRIPTION
Unintentionally discovered that imports from `react-dom/server.js` do not work(was able to easily write my own small binding for this, but this is an easy fix and totally doable). Tested on test-utils as well, same thing