### PR TITLE
React 18

### DIFF
--- a/src/React.res
+++ b/src/React.res
@@ -371,7 +371,8 @@ external useImperativeHandle7: (
 
 @module("react") external useDeferredValue: 'value => 'value = "useDeferredValue"
 
-@module("react") external useTransition: unit => (bool, @uncurry (unit => unit)) = "useTransition"
+@module("react")
+external useTransition: unit => (bool, (. unit => unit) => unit) = "useTransition"
 
 @module("react")
 external useInsertionEffect: (@uncurry (unit => option<unit => unit>)) => unit =

--- a/src/React.res
+++ b/src/React.res
@@ -367,6 +367,59 @@ external useImperativeHandle7: (
   ('a, 'b, 'c, 'd, 'e, 'f, 'g),
 ) => unit = "useImperativeHandle"
 
+@module("react") external useId: unit => string = "useId"
+
+@module("useDeferredValue") external useDeferredValue: 'value => 'value = "useDeferredValue"
+
+@module("react") external useTransition: unit => (bool, @uncurry (unit => unit)) = "useTransition"
+
+@module("react")
+external useInsertionEffect: (@uncurry (unit => option<unit => unit>)) => unit =
+  "useInsertionEffect"
+@module("react")
+external useInsertionEffect0: (@uncurry (unit => option<unit => unit>), @as(json`[]`) _) => unit =
+  "useInsertionEffect"
+@module("react")
+external useInsertionEffect1: (@uncurry (unit => option<unit => unit>), array<'a>) => unit =
+  "useInsertionEffect"
+@module("react")
+external useInsertionEffect2: (@uncurry (unit => option<unit => unit>), ('a, 'b)) => unit =
+  "useInsertionEffect"
+@module("react")
+external useInsertionEffect3: (@uncurry (unit => option<unit => unit>), ('a, 'b, 'c)) => unit =
+  "useInsertionEffect"
+@module("react")
+external useInsertionEffect4: (@uncurry (unit => option<unit => unit>), ('a, 'b, 'c, 'd)) => unit =
+  "useInsertionEffect"
+@module("react")
+external useInsertionEffect5: (
+  @uncurry (unit => option<unit => unit>),
+  ('a, 'b, 'c, 'd, 'e),
+) => unit = "useInsertionEffect"
+@module("react")
+external useInsertionEffect6: (
+  @uncurry (unit => option<unit => unit>),
+  ('a, 'b, 'c, 'd, 'e, 'f),
+) => unit = "useInsertionEffect"
+@module("react")
+external useInsertionEffect7: (
+  @uncurry (unit => option<unit => unit>),
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g),
+) => unit = "useInsertionEffect"
+
+@module("react")
+external useSyncExternalStore: (
+  @uncurry (unit => @uncurry (unit => unit)),
+  @uncurry unit => 'state,
+) => 'state = "useSyncExternalStore"
+
+@module("react")
+external useSyncExternalStoreWithServerSnapshot: (
+  @uncurry (unit => @uncurry (unit => unit)),
+  @uncurry unit => 'state,
+  @uncurry unit => 'state,
+) => 'state = "useSyncExternalStore"
+
 module Uncurried = {
   @module("react")
   external useState: (@uncurry (unit => 'state)) => ('state, (. 'state => 'state) => unit) =
@@ -432,14 +485,6 @@ module Uncurried = {
     ('a, 'b, 'c, 'd, 'e, 'f, 'g),
   ) => callback<'input, 'output> = "useCallback"
 }
-
-type transitionConfig = {timeoutMs: int}
-
-@module("react")
-external useTransition: (
-  ~config: transitionConfig=?,
-  unit,
-) => (callback<callback<unit, unit>, unit>, bool) = "useTransition"
 
 @set
 external setDisplayName: (component<'props>, string) => unit = "displayName"

--- a/src/React.res
+++ b/src/React.res
@@ -372,7 +372,7 @@ external useImperativeHandle7: (
 @module("react") external useDeferredValue: 'value => 'value = "useDeferredValue"
 
 @module("react")
-external useTransition: unit => (bool, (. unit => unit) => unit) = "useTransition"
+external useTransition: unit => (bool, unit => unit) = "useTransition"
 
 @module("react")
 external useInsertionEffect: (@uncurry (unit => option<unit => unit>)) => unit =
@@ -410,15 +410,15 @@ external useInsertionEffect7: (
 
 @module("react")
 external useSyncExternalStore: (
-  @uncurry (unit => @uncurry (unit => unit)),
-  @uncurry unit => 'state,
+  ~subscribe: @uncurry ((unit => unit) => ((. unit) => unit)),
+  ~getSnapshot: @uncurry unit => 'state,
 ) => 'state = "useSyncExternalStore"
 
 @module("react")
 external useSyncExternalStoreWithServerSnapshot: (
-  @uncurry (unit => @uncurry (unit => unit)),
-  @uncurry unit => 'state,
-  @uncurry unit => 'state,
+  ~subscribe: @uncurry ((unit => unit) => ((. unit) => unit)),
+  ~getSnapshot: @uncurry unit => 'state,
+  ~getServerSnapshot: @uncurry unit => 'state,
 ) => 'state = "useSyncExternalStore"
 
 module Uncurried = {

--- a/src/React.res
+++ b/src/React.res
@@ -369,7 +369,7 @@ external useImperativeHandle7: (
 
 @module("react") external useId: unit => string = "useId"
 
-@module("useDeferredValue") external useDeferredValue: 'value => 'value = "useDeferredValue"
+@module("react") external useDeferredValue: 'value => 'value = "useDeferredValue"
 
 @module("react") external useTransition: unit => (bool, @uncurry (unit => unit)) = "useTransition"
 

--- a/src/React.res
+++ b/src/React.res
@@ -372,7 +372,7 @@ external useImperativeHandle7: (
 @module("react") external useDeferredValue: 'value => 'value = "useDeferredValue"
 
 @module("react")
-external useTransition: unit => (bool, unit => unit) = "useTransition"
+external useTransition: unit => (bool, (. unit => unit) => unit) = "useTransition"
 
 @module("react")
 external useInsertionEffect: (@uncurry (unit => option<unit => unit>)) => unit =

--- a/src/ReactDOM.bs.js
+++ b/src/ReactDOM.bs.js
@@ -2,7 +2,11 @@
 'use strict';
 
 
-var Experimental = {};
+var Root = {};
+
+var Client = {
+  Root: Root
+};
 
 var Ref = {};
 
@@ -10,7 +14,7 @@ var Props = {};
 
 var Style;
 
-exports.Experimental = Experimental;
+exports.Client = Client;
 exports.Ref = Ref;
 exports.Props = Props;
 exports.Style = Style;

--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -10,27 +10,35 @@
 external querySelector: string => option<Dom.element> = "document.querySelector"
 
 @module("react-dom")
-@deprecated("ReactDOM.render is no longer supported in React 18. Use createRoot instead.")
+@deprecated("ReactDOM.render is no longer supported in React 18. Use ReactDOM.Client.createRoot instead.")
 external render: (React.element, Dom.element) => unit = "render"
 
-module Root = {
-  type t
+module Client = {
 
-  @send external render: (t, React.element) => unit = "render"
+  module Root = {
+    type t
 
-  @send external unmount: (t, unit) => unit = "unmount"
+    @send external render: (t, React.element) => unit = "render"
+
+    @send external unmount: (t, unit) => unit = "unmount"
+  }
+
+  @module("react-dom/client")
+  external createRoot: Dom.element => Root.t = "createRoot"
+
+  @module("react-dom/client")
+  external hydrateRoot: (Dom.element, React.element) => Root.t = "hydrateRoot"
 }
 
 @module("react-dom")
-external createRoot: Dom.element => Root.t = "createRoot"
-
-@module("react-dom")
+@deprecated("ReactDOM.hydrate is no longer supported in React 18. Use ReactDOM.Client.hydrateRoot instead.")
 external hydrate: (React.element, Dom.element) => unit = "hydrate"
 
 @module("react-dom")
 external createPortal: (React.element, Dom.element) => React.element = "createPortal"
 
 @module("react-dom")
+@deprecated("ReactDOM.unmountComponentAtNode is no longer supported in React 18. Use ReactDOM.Client.Root.unmount instead.")
 external unmountComponentAtNode: Dom.element => unit = "unmountComponentAtNode"
 
 external domElementToObj: Dom.element => {..} = "%identity"

--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -10,19 +10,19 @@
 external querySelector: string => option<Dom.element> = "document.querySelector"
 
 @module("react-dom")
+@deprecated("ReactDOM.render is no longer supported in React 18. Use createRoot instead.")
 external render: (React.element, Dom.element) => unit = "render"
 
-module Experimental = {
-  type root
+module Root = {
+  type t
 
-  @module("react-dom/client")
-  external createRoot: Dom.element => root = "createRoot"
+  @send external render: (t, React.element) => unit = "render"
 
-  @module("react-dom/client")
-  external createBlockingRoot: Dom.element => root = "createBlockingRoot"
-
-  @send external render: (root, React.element) => unit = "render"
+  @send external unmount: (t, unit) => unit = "unmount"
 }
+
+@module("react-dom")
+external createRoot: Dom.element => Root.t = "createRoot"
 
 @module("react-dom")
 external hydrate: (React.element, Dom.element) => unit = "hydrate"

--- a/src/v3/ReactDOM_V3.res
+++ b/src/v3/ReactDOM_V3.res
@@ -13,7 +13,7 @@ external querySelector: string => option<Dom.element> = "document.querySelector"
 external render: (React.element, Dom.element) => unit = "render"
 
 module Experimental = {
-  type root = ReactDOM.Experimental.root
+  type root = ReactDOM.Client.Root.t
 
   @module("react-dom")
   external createRoot: Dom.element => root = "createRoot"

--- a/src/v3/React_V3.res
+++ b/src/v3/React_V3.res
@@ -437,11 +437,8 @@ module Uncurried = {
   ) => callback<'input, 'output> = "useCallback"
 }
 
-type transitionConfig = React.transitionConfig
-
 @module("react")
 external useTransition: (
-  ~config: transitionConfig=?,
   unit,
 ) => (callback<callback<unit, unit>, unit>, bool) = "useTransition"
 

--- a/src/v3/React_V3.res
+++ b/src/v3/React_V3.res
@@ -438,9 +438,7 @@ module Uncurried = {
 }
 
 @module("react")
-external useTransition: (
-  unit,
-) => (callback<callback<unit, unit>, unit>, bool) = "useTransition"
+external useTransition: unit => (bool, (. unit => unit) => unit) = "useTransition"
 
 @set
 external setDisplayName: (component<'props>, string) => unit = "displayName"


### PR DESCRIPTION
Closes #34

Per @tom-sherman's instructions, I forked his `react-18` branch and added a couple of commits. I attempted to mirror the React 18.1 documentation:
- upgraded to react and react-dom 18.1
- deprecated ReactDOM.hydrate, ReactDOM.unmountComponentAtNode
- added ReactDOM.Client to encapsulate `createRoot`, `hydrateRoot`, and `Root` module

I'm happy to modify as needed and do any additional work to close #34, but I'm pretty new to ReScript (background in Clojure and OCaml) so please advise on the following:
- I do not know how to run tests correctly. Running `node test/React__test.bs.js` did not work
- Introducing the `Client` module is my attempt to mirror React 18.1 but may not be the proper way to do things in ReScript
- There is probably a much more efficient way to detect changes between the alpha and release of React 18 than hunting through documentation and javascript code.
- If someone with more experience lists the remaining work, I have some time to tackle it.
