### PR TITLE
Use @react.component for ErrorBoundary

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- Nothing yet
+- Rewrite the `RescriptReactErrorBoundary` component implementation with `@react.component`, so it can be compatible with the changes of JSX PPX.
 
 ## v0.10.3
 
@@ -26,12 +26,14 @@ For history on previous evolution of the code, check out the original [reason-re
 - **IMPORTANT:** Currently, old third-party packages that are still dependent on `reason-react` will not mix with other `@rescript/react` based code due to a build system problem. Which means that every third-party dependency needs to be upgraded to `@rescript/react` first to make it compatible. See [this forum discussion](https://forum.rescript-lang.org/t/discussion-reason-react-rescript-react-migration-path/1086) for more details.
 
 - Removed legacy modules ("record api"):
+
   - `ReasonReactCompat`
   - `ReactDOMServerRe`
   - `ReactEventRe`
   - `ReasonReactOptimizedCreateClass`
 
 - Renamed existing modules:
+
   - `ReasonReactErrorBoundary` -> `RescriptReactErrorBoundary`
   - `ReasonReactRouter` -> `RescriptReactRouter`
   - (Note: Usually the two only valid styles would be `ReScript` or `rescript`, the latter being the version for technical writing. We are using `Rescript` here, since it is essentially the capitalized version of `rescript`)

--- a/src/RescriptReactErrorBoundary.res
+++ b/src/RescriptReactErrorBoundary.res
@@ -14,7 +14,7 @@ type params<'error> = {
   info: info,
 }
 
-let getErrorBoundary = %raw(`
+let getErrorBoundary: reactComponentClass => React.element = %raw(`
   function (Component) {
     function ErrorBoundary(props) {
       Component.call(this);
@@ -31,12 +31,6 @@ let getErrorBoundary = %raw(`
   }
 `)
 
-@obj
-external makeProps: (
-  ~children: React.element,
-  ~fallback: params<'error> => React.element,
-  ~key: string=?,
-  unit,
-) => {"children": React.element, "fallback": params<'error> => React.element} = ""
-
-let make = getErrorBoundary(component)
+@react.component
+let make = (~children as _: React.element, ~fallback as _: params<'error> => React.element) =>
+  getErrorBoundary(component)


### PR DESCRIPTION
I've rewrite `RescriptReactErrorBoundary` component implementation with `@react.component`. It is written without it, then it is vulnerable to being broken in case JSX PPX output is changed. Related [discussion](https://github.com/rescript-lang/syntax/pull/547#issuecomment-1159857861) in the PR of JSX V4 of syntax repo.