### PR TITLE
Change react-dom to react-dom/client

### DIFF
--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -15,10 +15,10 @@ external render: (React.element, Dom.element) => unit = "render"
 module Experimental = {
   type root
 
-  @module("react-dom")
+  @module("react-dom/client")
   external createRoot: Dom.element => root = "createRoot"
 
-  @module("react-dom")
+  @module("react-dom/client")
   external createBlockingRoot: Dom.element => root = "createBlockingRoot"
 
   @send external render: (root, React.element) => unit = "render"


### PR DESCRIPTION
React recommends importing the client for the new create root API. Importing from "react-dom" throws this warning in React 18 

> Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client

In my project I use this modification and it removes the error.