### PR TITLE
Fix ErrorBoundary component using external binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ _build
 
 # Editor
 /.idea/
+
+# React
+!/src/react/*.js

--- a/src/RescriptReactErrorBoundary.res
+++ b/src/RescriptReactErrorBoundary.res
@@ -3,10 +3,6 @@
  * As soon as React provides a mechanism for error-catching using functional component,
  * this is likely to be deprecated and/or move to user space.
  ")
-type reactComponentClass
-
-@module("react") external component: reactComponentClass = "Component"
-
 type info = {componentStack: string}
 
 type params<'error> = {
@@ -14,23 +10,29 @@ type params<'error> = {
   info: info,
 }
 
-let getErrorBoundary: reactComponentClass => React.element = %raw(`
-  function (Component) {
-    function ErrorBoundary(props) {
-      Component.call(this);
-      this.state = {error: undefined};
-    };
-    ErrorBoundary.prototype = Object.create(Component.prototype);
-    ErrorBoundary.prototype.componentDidCatch = function(error, info) {
-      this.setState({error: {error: error, info: info}})
-    };
-    ErrorBoundary.prototype.render = function() {
-      return this.state.error != undefined ? this.props.fallback(this.state.error) : this.props.children
-    }
-    return ErrorBoundary;
+%%raw(`
+var React = require("react");
+
+var ErrorBoundary = (function (Component) {
+  function ErrorBoundary(props) {
+    Component.call(this);
+    this.state = { error: undefined };
   }
+  ErrorBoundary.prototype = Object.create(Component.prototype);
+  ErrorBoundary.prototype.componentDidCatch = function (error, info) {
+    this.setState({ error: { error: error, info: info } });
+  };
+  ErrorBoundary.prototype.render = function () {
+    return this.state.error != undefined
+      ? this.props.fallback(this.state.error)
+      : this.props.children;
+  };
+  return ErrorBoundary;
+})(React.Component);
 `)
 
-@react.component
-let make = (~children as _: React.element, ~fallback as _: params<'error> => React.element) =>
-  getErrorBoundary(component)
+@react.component @val
+external make: (
+  ~children: React.element,
+  ~fallback: params<'error> => React.element,
+) => React.element = "ErrorBoundary"


### PR DESCRIPTION
I found the critical error during the thorough test for V10.
```
Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.
    at RescriptReactErrorBoundary
```
This warning is not caused by V10, however, the generated js representation needs to be fit to React API.
I tried to implement the ErrorBoundary component by using jsx ppx, but no gain so far. I think I should revert it and look later.