### PR TITLE
dom: add allow and frameBorder props

### DIFF
--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -1292,7 +1292,7 @@ module Props = {
     @optional
     formMethod: string /* "post", "get", "put" */,
     @optional
-    frameBorder: int,
+    frameBorder: int, /* deprecated, prefer to use css border instead */
     @optional
     headers: string,
     @optional

--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -1234,6 +1234,8 @@ module Props = {
     @optional
     action: string /* uri */,
     @optional
+    allow: string,
+    @optional
     allowFullScreen: bool,
     @optional
     alt: string,
@@ -1289,6 +1291,8 @@ module Props = {
     formTarget: string /* "_blank", "_self", etc. */,
     @optional
     formMethod: string /* "post", "get", "put" */,
+    @optional
+    frameBorder: int,
     @optional
     headers: string,
     @optional


### PR DESCRIPTION
These are iframe-specific attributes:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-frameborder

And while the latter is also deprecated, Youtube still generates embed code that uses it and it is still explicitly supported by React.js: https://github.com/facebook/react/blob/ca106a02d1648f4f0048b07c6b88f69aac175d3c/packages/react-dom/src/shared/possibleStandardNames.js#L70 