### PR TITLE
Deprecated more props types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.11.0-alpha.2
 
 - Relax React version requirement to v18.0.0+.
-- Deprecated type `ReactDOM.props`
+- Deprecated types `ReactDOM.props`, `ReactDOM.Props.props`, `ReactDOM.Props.domProps`.
 
 **Breaking:**
 

--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -56,12 +56,18 @@ module Ref = {
   external callbackDomRef: callbackDomRef => domRef = "%identity"
 }
 
+type domProps = JsxDOM.domProps
+
+@deprecated("Please use type ReactDOM.domProps")
+type props = JsxDOM.domProps
+
 module Props = {
+  @deprecated("Please use type ReactDOM.domProps")
   type domProps = JsxDOM.domProps
 
   /** DEPRECATED */
   @deriving(abstract)
-  @deprecated("Please use type domProps")
+  @deprecated("Please use type ReactDOM.domProps")
   type props = {
     @optional
     key: string,
@@ -1084,10 +1090,8 @@ module Props = {
   }
 }
 
-include Props
-
 @variadic @module("react")
-external createElement: (string, ~props: props=?, array<React.element>) => React.element =
+external createElement: (string, ~props: domProps=?, array<React.element>) => React.element =
   "createElement"
 
 @variadic @module("react")

--- a/src/legacy/ReactDOMRe.res
+++ b/src/legacy/ReactDOMRe.res
@@ -2,16 +2,17 @@
 This module is kept for ReScript react-jsx v3 compatibility
 We removed all functionality that is not needed for JSX usage
 **/
-
-include ReactDOM.Props
-
-@variadic @module("react")
+@variadic
+@module("react")
 external createDOMElementVariadic: (
   string,
-  ~props: domProps=?,
+  ~props: ReactDOM.domProps=?,
   array<React.element>,
 ) => React.element = "createElement"
 
 @variadic @module("react")
-external createElement: (string, ~props: props=?, array<React.element>) => React.element =
-  "createElement"
+external createElement: (
+  string,
+  ~props: ReactDOM.domProps=?,
+  array<React.element>,
+) => React.element = "createElement"

--- a/src/legacy/ReactDOMRe.res
+++ b/src/legacy/ReactDOMRe.res
@@ -6,13 +6,13 @@ We removed all functionality that is not needed for JSX usage
 @module("react")
 external createDOMElementVariadic: (
   string,
-  ~props: ReactDOM.domProps=?,
+  ~props: ReactDOM_V3.domProps=?,
   array<React.element>,
 ) => React.element = "createElement"
 
 @variadic @module("react")
 external createElement: (
   string,
-  ~props: ReactDOM.domProps=?,
+  ~props: ReactDOM_V3.domProps=?,
   array<React.element>,
 ) => React.element = "createElement"


### PR DESCRIPTION
Deprecate `ReactDOM.props`, `ReactDOM.Props.props`, `ReactDOM.Props.domProps`.

`ReactDOM.domProps` is the way to go. 🙂