### PR TITLE
Update Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 - Relax React version requirement to v18.0.0+.
 - Deprecated types `ReactDOM.props`, `ReactDOM.Props.props`, `ReactDOM.Props.domProps`.
 
-**Breaking:**
-
-- Changed the attribute `method` to `method_` of DOM element in `ReactDOM.domProps`
-
 ## 0.11.0-alpha.1
 
 - `RescriptReactErrorBoundary` component now implemented using `@react.component`, so it is compatible with JSX V4.


### PR DESCRIPTION
As of rewriting `JsxDom.ml` to res in the compiler https://github.com/rescript-lang/rescript-compiler/blob/f0ba004aa65a2e704941ac97d16151d14d79615b/jscomp/others/jsxDOM.res#L213, `method` is not breaking change now.