### PR TITLE
Fix addKeyProp to not mutate props object

### DIFF
--- a/src/React.bs.js
+++ b/src/React.bs.js
@@ -9,7 +9,7 @@ function component(prim) {
 }
 
 function createElementWithKey(key, component, props) {
-  return React.createElement(component, key !== undefined ? Object.assign(props, {
+  return React.createElement(component, key !== undefined ? Object.assign({}, props, {
                     key: key
                   }) : props);
 }
@@ -17,7 +17,7 @@ function createElementWithKey(key, component, props) {
 function createElementVariadicWithKey(key, component, props, elements) {
   return Caml_splice_call.spliceApply(React.createElement, [
               component,
-              key !== undefined ? Object.assign(props, {
+              key !== undefined ? Object.assign({}, props, {
                       key: key
                     }) : props,
               elements

--- a/src/React.res
+++ b/src/React.res
@@ -15,10 +15,13 @@ type component<'props> = Jsx.component<'props>
 let component = Jsx.component
 
 %%private(
+  @val
+  external propsWithKey: (@as(json`{}`) _, 'props, {"key": string}) => 'props = "Object.assign"
+
   @inline
   let addKeyProp = (~key: option<string>=?, p: 'props): 'props =>
     switch key {
-    | Some(key) => Obj.magic(Js.Obj.assign(Obj.magic(p), {"key": key}))
+    | Some(key) => propsWithKey(p, {"key": key})
     | None => p
     }
 )


### PR DESCRIPTION
I just noticed that the existing implementation of `addKeyProp` is mutating the props, just like the

```rescript
(props->Obj.magic)["key"] = key
```

idea that we discussed previously.

This is because `Object.assign` mutates its first argument.
This PR fixes that.