### PR TITLE
Update React_V3.ref to define record fields

### DIFF
--- a/src/v3/React_V3.res
+++ b/src/v3/React_V3.res
@@ -38,7 +38,7 @@ external jsxs: (component<'props>, 'props) => element = "jsxs"
 @module("react") @deprecated("Please use JSX syntax directly.")
 external jsxsKeyed: (component<'props>, 'props, string) => element = "jsxs"
 
-type ref<'value> = React.ref<'value>
+type ref<'value> = React.ref<'value> = {mutable current: 'value}
 
 module Ref = {
   @deprecated("Please use the type React.ref instead")


### PR DESCRIPTION
With this change we can refer to `.current` field of the record by opening the module.

Previously the following code would fail to compile with "  The record field React.current can't be found."

```res
open ReactV3

@get external videoWidth: Dom.Element.t => float = "videoWidth"
@get external videoHeight: Dom.Element.t => float = "videoHeight"

let getVideoDimensions = videoRef =>
  videoRef.React.current
  ->Js.Nullable.toOption
  ->Option.map(video => (video->videoWidth, video->videoHeight))
```