### PR TITLE
Compatibility with ReScript 11 uncurried mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.0-rc.1
+
+- Compatibility with ReScript 11 uncurried mode.
+- Breaking: removed `React.callback` type.
+
 ## 0.11.0
 
 No changes compared to rc.3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rescript": "^10.1.0"
+        "rescript": "^11.0.0-alpha.1"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -59,14 +59,13 @@
       }
     },
     "node_modules/rescript": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.0.tgz",
-      "integrity": "sha512-85KLtBECo+hYwObbifXk5xpxUCUFMWgCR1w7hDDGhhXIXqEpHQ2ds6o++YPxzXjLuU1/qA7Iovq2zUX4opejQw==",
+      "version": "11.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.0-alpha.1.tgz",
+      "integrity": "sha512-+01rdTX9FCOZrEJFVrk2XRgrIlGLf93EKsNwoW5iq0jQiKcYGCdHeSbJvVYF+cximgm+CmWhSkR42l+Il6t12A==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
         "bsc": "bsc",
-        "bsrefmt": "bsrefmt",
         "bstracing": "lib/bstracing",
         "rescript": "rescript"
       }
@@ -117,9 +116,9 @@
       }
     },
     "rescript": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/rescript/-/rescript-10.1.0.tgz",
-      "integrity": "sha512-85KLtBECo+hYwObbifXk5xpxUCUFMWgCR1w7hDDGhhXIXqEpHQ2ds6o++YPxzXjLuU1/qA7Iovq2zUX4opejQw==",
+      "version": "11.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/rescript/-/rescript-11.0.0-alpha.1.tgz",
+      "integrity": "sha512-+01rdTX9FCOZrEJFVrk2XRgrIlGLf93EKsNwoW5iq0jQiKcYGCdHeSbJvVYF+cximgm+CmWhSkR42l+Il6t12A==",
       "dev": true
     },
     "scheduler": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rescript": "^10.1.0"
+    "rescript": "^11.0.0-alpha.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/src/React.res
+++ b/src/React.res
@@ -401,13 +401,13 @@ external useInsertionEffect7: (
 
 @module("react")
 external useSyncExternalStore: (
-  ~subscribe: @uncurry (unit => unit, . unit) => unit,
+  ~subscribe: @uncurry ((unit => unit) => (. unit) => unit),
   ~getSnapshot: @uncurry unit => 'state,
 ) => 'state = "useSyncExternalStore"
 
 @module("react")
 external useSyncExternalStoreWithServerSnapshot: (
-  ~subscribe: @uncurry (unit => unit, . unit) => unit,
+  ~subscribe: @uncurry ((unit => unit) => (. unit) => unit),
   ~getSnapshot: @uncurry unit => 'state,
   ~getServerSnapshot: @uncurry unit => 'state,
 ) => 'state = "useSyncExternalStore"

--- a/src/React.res
+++ b/src/React.res
@@ -249,53 +249,32 @@ external useMemo6: (@uncurry (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f)) => 'any =
 @module("react")
 external useMemo7: (@uncurry (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'any = "useMemo"
 
-/* This is used as return values */
-type callback<'input, 'output> = 'input => 'output
+@module("react")
+external useCallback: 'f => 'f = "useCallback"
 
 @module("react")
-external useCallback: (@uncurry ('input => 'output)) => callback<'input, 'output> = "useCallback"
+external useCallback0: ('f, @as(json`[]`) _) => 'f = "useCallback"
 
 @module("react")
-external useCallback0: (
-  @uncurry ('input => 'output),
-  @as(json`[]`) _,
-) => callback<'input, 'output> = "useCallback"
+external useCallback1: ('f, array<'a>) => 'f = "useCallback"
 
 @module("react")
-external useCallback1: (@uncurry ('input => 'output), array<'a>) => callback<'input, 'output> =
-  "useCallback"
+external useCallback2: ('f, ('a, 'b)) => 'f = "useCallback"
 
 @module("react")
-external useCallback2: (@uncurry ('input => 'output), ('a, 'b)) => callback<'input, 'output> =
-  "useCallback"
+external useCallback3: ('f, ('a, 'b, 'c)) => 'f = "useCallback"
 
 @module("react")
-external useCallback3: (@uncurry ('input => 'output), ('a, 'b, 'c)) => callback<'input, 'output> =
-  "useCallback"
+external useCallback4: ('f, ('a, 'b, 'c, 'd)) => 'f = "useCallback"
 
 @module("react")
-external useCallback4: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd),
-) => callback<'input, 'output> = "useCallback"
+external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
 @module("react")
-external useCallback5: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd, 'e),
-) => callback<'input, 'output> = "useCallback"
+external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
 
 @module("react")
-external useCallback6: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd, 'e, 'f),
-) => callback<'input, 'output> = "useCallback"
-
-@module("react")
-external useCallback7: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd, 'e, 'f, 'g),
-) => callback<'input, 'output> = "useCallback"
+external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
 
 @module("react")
 external useContext: Context.t<'any> => 'any = "useContext"
@@ -430,52 +409,32 @@ module Uncurried = {
     @uncurry ('initialState => 'state),
   ) => ('state, (. 'action) => unit) = "useReducer"
 
-  type callback<'input, 'output> = (. 'input) => 'output
+  @module("react")
+  external useCallback: 'f => 'f = "useCallback"
 
   @module("react")
-  external useCallback: (@uncurry ('input => 'output)) => callback<'input, 'output> = "useCallback"
+  external useCallback0: ('f, @as(json`[]`) _) => 'f = "useCallback"
 
   @module("react")
-  external useCallback0: (
-    @uncurry ('input => 'output),
-    @as(json`[]`) _,
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback1: ('f, array<'a>) => 'f = "useCallback"
 
   @module("react")
-  external useCallback1: (@uncurry ('input => 'output), array<'a>) => callback<'input, 'output> =
-    "useCallback"
+  external useCallback2: ('f, ('a, 'b)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback2: (@uncurry ('input => 'output), ('a, 'b)) => callback<'input, 'output> =
-    "useCallback"
+  external useCallback3: ('f, ('a, 'b, 'c)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback3: (@uncurry ('input => 'output), ('a, 'b, 'c)) => callback<'input, 'output> =
-    "useCallback"
+  external useCallback4: ('f, ('a, 'b, 'c, 'd)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback4: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd),
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback5: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd, 'e),
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback6: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd, 'e, 'f),
-  ) => callback<'input, 'output> = "useCallback"
-
-  @module("react")
-  external useCallback7: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd, 'e, 'f, 'g),
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
 }
 
 @set

--- a/src/ReactTestUtils.bs.js
+++ b/src/ReactTestUtils.bs.js
@@ -8,14 +8,14 @@ var Caml_option = require("rescript/lib/js/caml_option.js");
 var TestUtils = require("react-dom/test-utils");
 
 function act(func) {
-  var reactFunc = function () {
+  var reactFunc = function (param) {
     Curry._1(func, undefined);
   };
   TestUtils.act(reactFunc);
 }
 
 function actAsync(func) {
-  return TestUtils.act(function () {
+  return TestUtils.act(function (param) {
               return Curry._1(func, undefined);
             });
 }

--- a/src/RescriptReactRouter.bs.js
+++ b/src/RescriptReactRouter.bs.js
@@ -182,7 +182,7 @@ function unwatchUrl(watcherID) {
 }
 
 function useUrl(serverUrl, param) {
-  var match = React.useState(function () {
+  var match = React.useState(function (param) {
         if (serverUrl !== undefined) {
           return serverUrl;
         } else {
@@ -191,7 +191,7 @@ function useUrl(serverUrl, param) {
       });
   var setUrl = match[1];
   var url$1 = match[0];
-  React.useEffect((function () {
+  React.useEffect((function (param) {
           var watcherId = watchUrl(function (url) {
                 Curry._1(setUrl, (function (param) {
                         return url;

--- a/src/v3/React_V3.res
+++ b/src/v3/React_V3.res
@@ -262,53 +262,32 @@ external useMemo6: (@uncurry (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f)) => 'any =
 @module("react")
 external useMemo7: (@uncurry (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'any = "useMemo"
 
-/* This is used as return values */
-type callback<'input, 'output> = React.callback<'input, 'output>
+@module("react")
+external useCallback: 'f => 'f = "useCallback"
 
 @module("react")
-external useCallback: (@uncurry ('input => 'output)) => callback<'input, 'output> = "useCallback"
+external useCallback0: ('f, @as(json`[]`) _) => 'f = "useCallback"
 
 @module("react")
-external useCallback0: (
-  @uncurry ('input => 'output),
-  @as(json`[]`) _,
-) => callback<'input, 'output> = "useCallback"
+external useCallback1: ('f, array<'a>) => 'f = "useCallback"
 
 @module("react")
-external useCallback1: (@uncurry ('input => 'output), array<'a>) => callback<'input, 'output> =
-  "useCallback"
+external useCallback2: ('f, ('a, 'b)) => 'f = "useCallback"
 
 @module("react")
-external useCallback2: (@uncurry ('input => 'output), ('a, 'b)) => callback<'input, 'output> =
-  "useCallback"
+external useCallback3: ('f, ('a, 'b, 'c)) => 'f = "useCallback"
 
 @module("react")
-external useCallback3: (@uncurry ('input => 'output), ('a, 'b, 'c)) => callback<'input, 'output> =
-  "useCallback"
+external useCallback4: ('f, ('a, 'b, 'c, 'd)) => 'f = "useCallback"
 
 @module("react")
-external useCallback4: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd),
-) => callback<'input, 'output> = "useCallback"
+external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
 @module("react")
-external useCallback5: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd, 'e),
-) => callback<'input, 'output> = "useCallback"
+external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
 
 @module("react")
-external useCallback6: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd, 'e, 'f),
-) => callback<'input, 'output> = "useCallback"
-
-@module("react")
-external useCallback7: (
-  @uncurry ('input => 'output),
-  ('a, 'b, 'c, 'd, 'e, 'f, 'g),
-) => callback<'input, 'output> = "useCallback"
+external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
 
 @module("react")
 external useContext: Context.t<'any> => 'any = "useContext"
@@ -389,52 +368,32 @@ module Uncurried = {
     @uncurry ('initialState => 'state),
   ) => ('state, (. 'action) => unit) = "useReducer"
 
-  type callback<'input, 'output> = React.callback<'input, 'output>
+  @module("react")
+  external useCallback: 'f => 'f = "useCallback"
 
   @module("react")
-  external useCallback: (@uncurry ('input => 'output)) => callback<'input, 'output> = "useCallback"
+  external useCallback0: ('f, @as(json`[]`) _) => 'f = "useCallback"
 
   @module("react")
-  external useCallback0: (
-    @uncurry ('input => 'output),
-    @as(json`[]`) _,
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback1: ('f, array<'a>) => 'f = "useCallback"
 
   @module("react")
-  external useCallback1: (@uncurry ('input => 'output), array<'a>) => callback<'input, 'output> =
-    "useCallback"
+  external useCallback2: ('f, ('a, 'b)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback2: (@uncurry ('input => 'output), ('a, 'b)) => callback<'input, 'output> =
-    "useCallback"
+  external useCallback3: ('f, ('a, 'b, 'c)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback3: (@uncurry ('input => 'output), ('a, 'b, 'c)) => callback<'input, 'output> =
-    "useCallback"
+  external useCallback4: ('f, ('a, 'b, 'c, 'd)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback4: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd),
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback5: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd, 'e),
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback6: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd, 'e, 'f),
-  ) => callback<'input, 'output> = "useCallback"
-
-  @module("react")
-  external useCallback7: (
-    @uncurry ('input => 'output),
-    ('a, 'b, 'c, 'd, 'e, 'f, 'g),
-  ) => callback<'input, 'output> = "useCallback"
+  external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
 }
 
 @module("react")


### PR DESCRIPTION
- Upgrade ReScript dev dependency to 11.0.0 alpha 1 so that curried after uncurried is not fused anymore on reformat.
- Fix signature of `useSyncExternalStore` bindings.
- Fix/relax signature of `useCallback` bindings to work with different arities.
- Remove type `React.callback` which is not needed anymore.