### PR TITLE
Fix children type for Fragment, StrictMode and Suspense

### DIFF
--- a/src/React.bs.js
+++ b/src/React.bs.js
@@ -16,12 +16,6 @@ var StrictMode = {};
 
 var Suspense = {};
 
-var SuspenseList = {};
-
-var Experimental = {
-  SuspenseList: SuspenseList
-};
-
 function lazy_(load) {
   return React.lazy(async function (param) {
               return {
@@ -38,7 +32,6 @@ exports.Context = Context;
 exports.Fragment = Fragment;
 exports.StrictMode = StrictMode;
 exports.Suspense = Suspense;
-exports.Experimental = Experimental;
 exports.lazy_ = lazy_;
 exports.Uncurried = Uncurried;
 /* react Not a pure module */

--- a/src/React.res
+++ b/src/React.res
@@ -127,22 +127,6 @@ module Suspense = {
   external make: component<props<'children, 'fallback>> = "Suspense"
 }
 
-module Experimental = {
-  module SuspenseList = {
-    type revealOrder
-    type tail
-    type props<'children, 'revealOrder, 'tail> = {
-      key?: string,
-      children?: 'children,
-      revealOrder?: 'revealOrder,
-      tail?: 'tail,
-    }
-
-    @module("react")
-    external make: component<props<'children, 'revealOrder, 'tail>> = "SuspenseList"
-  }
-}
-
 type dynamicallyImportedModule<'a> = {default: component<'a>}
 
 @module("react")

--- a/src/React.res
+++ b/src/React.res
@@ -39,9 +39,9 @@ external jsxs: (component<'props>, 'props) => element = "jsxs"
 @module("react/jsx-runtime")
 external jsxsKeyed: (component<'props>, 'props, ~key: string=?, @ignore unit) => element = "jsxs"
 
-type fragmentProps<'children> = {children?: 'children}
+type fragmentProps = {children?: element}
 
-@module("react/jsx-runtime") external jsxFragment: component<fragmentProps<'children>> = "Fragment"
+@module("react/jsx-runtime") external jsxFragment: component<fragmentProps> = "Fragment"
 
 type ref<'value> = {mutable current: 'value}
 
@@ -104,27 +104,27 @@ external memoCustomCompareProps: (
   @uncurry ('props, 'props) => bool,
 ) => component<'props> = "memo"
 
-@module("react") external fragment: 'a = "Fragment"
+@module("react") external fragment: component<fragmentProps> = "Fragment"
 
 module Fragment = {
-  type props<'children> = {key?: string, children: 'children}
+  type props = {key?: string, children: element}
 
   @module("react")
-  external make: component<props<'children>> = "Fragment"
+  external make: component<props> = "Fragment"
 }
 
 module StrictMode = {
-  type props<'children> = {key?: string, children: 'children}
+  type props = {key?: string, children: element}
 
   @module("react")
-  external make: component<props<'children>> = "StrictMode"
+  external make: component<props> = "StrictMode"
 }
 
 module Suspense = {
-  type props<'children, 'fallback> = {key?: string, children?: 'children, fallback?: 'fallback}
+  type props = {key?: string, children?: element, fallback?: element}
 
   @module("react")
-  external make: component<props<'children, 'fallback>> = "Suspense"
+  external make: component<props> = "Suspense"
 }
 
 type dynamicallyImportedModule<'a> = {default: component<'a>}

--- a/src/v3/React_V3.bs.js
+++ b/src/v3/React_V3.bs.js
@@ -14,12 +14,6 @@ var StrictMode = {};
 
 var Suspense = {};
 
-var SuspenseList = {};
-
-var Experimental = {
-  SuspenseList: SuspenseList
-};
-
 var Uncurried = {};
 
 exports.Ref = Ref;
@@ -28,6 +22,5 @@ exports.Context = Context;
 exports.Fragment = Fragment;
 exports.StrictMode = StrictMode;
 exports.Suspense = Suspense;
-exports.Experimental = Experimental;
 exports.Uncurried = Uncurried;
 /* No side effect */

--- a/src/v3/React_V3.res
+++ b/src/v3/React_V3.res
@@ -134,28 +134,6 @@ module Suspense = {
   }> = "Suspense"
 }
 
-module Experimental = {
-  module SuspenseList = {
-    type revealOrder = React.Experimental.SuspenseList.revealOrder
-    type tail = React.Experimental.SuspenseList.tail
-    @obj
-    external makeProps: (
-      ~children: element=?,
-      ~revealOrder: [#forwards | #backwards | #together]=?,
-      ~tail: [#collapsed | #hidden]=?,
-      unit,
-    ) => {"children": option<element>, "revealOrder": option<revealOrder>, "tail": option<tail>} =
-      ""
-
-    @module("react")
-    external make: component<{
-      "children": option<element>,
-      "revealOrder": option<revealOrder>,
-      "tail": option<tail>,
-    }> = "SuspenseList"
-  }
-}
-
 /* HOOKS */
 
 /*


### PR DESCRIPTION
Closes #93.

Also remove the experimental `SuspenseList` component as it is not part of the current React docs (https://react.dev/) anymore.