### PR TITLE
Fix incorrect type definitions in useCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 #### :bug: Bug Fix
 
 - Fixed children type for `Fragment`, `StrictMode` and `Suspense`.
+- Fixed the incorrect type definitions for `React.useCallback`
 
 #### :nail_care: Polish
 

--- a/src/React.res
+++ b/src/React.res
@@ -262,10 +262,10 @@ external useCallback4: ('f, ('a, 'b, 'c, 'd)) => 'f = "useCallback"
 external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
 @module("react")
-external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
+external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f0)) => 'f = "useCallback"
 
 @module("react")
-external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
+external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f0, 'g)) => 'f = "useCallback"
 
 @module("react")
 external useContext: Context.t<'any> => 'any = "useContext"
@@ -422,10 +422,10 @@ module Uncurried = {
   external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
+  external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f0)) => 'f = "useCallback"
 
   @module("react")
-  external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
+  external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f0, 'g)) => 'f = "useCallback"
 }
 
 @set

--- a/src/v3/React_V3.res
+++ b/src/v3/React_V3.res
@@ -262,10 +262,10 @@ external useCallback4: ('f, ('a, 'b, 'c, 'd)) => 'f = "useCallback"
 external useCallback5: ('f, ('a, 'b, 'c, 'd, 'e)) => 'f = "useCallback"
 
 @module("react")
-external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f)) => 'f = "useCallback"
+external useCallback6: ('f, ('a, 'b, 'c, 'd, 'e, 'f0)) => 'f = "useCallback"
 
 @module("react")
-external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'f = "useCallback"
+external useCallback7: ('f, ('a, 'b, 'c, 'd, 'e, 'f0, 'g)) => 'f = "useCallback"
 
 @module("react")
 external useContext: Context.t<'any> => 'any = "useContext"


### PR DESCRIPTION
This fixes the incorrect type definitions of `React.useCallback7, 8`.