### PR TITLE
Fix @uncurry usage

### DIFF
--- a/src/React.res
+++ b/src/React.res
@@ -394,14 +394,14 @@ external useInsertionEffect7: (
 @module("react")
 external useSyncExternalStore: (
   ~subscribe: @uncurry ((unit => unit) => (. unit) => unit),
-  ~getSnapshot: @uncurry unit => 'state,
+  ~getSnapshot: @uncurry (unit => 'state),
 ) => 'state = "useSyncExternalStore"
 
 @module("react")
 external useSyncExternalStoreWithServerSnapshot: (
   ~subscribe: @uncurry ((unit => unit) => (. unit) => unit),
-  ~getSnapshot: @uncurry unit => 'state,
-  ~getServerSnapshot: @uncurry unit => 'state,
+  ~getSnapshot: @uncurry (unit => 'state),
+  ~getServerSnapshot: @uncurry (unit => 'state),
 ) => 'state = "useSyncExternalStore"
 
 module Uncurried = {


### PR DESCRIPTION
After my fixes in https://github.com/rescript-lang/rescript-compiler/pull/6643, unused (non-`bs.*`) attributes warning are now reported in ReScript 12.

The usages of `@uncurry` in `useSyncExternalStore`/`useSyncExternalStoreWithServerSnapshot` were always incorrect.
This PR fixes them.