### PR TITLE
Swap `package.json`'s `bsconfig.json` entry for `rescript.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
-    "bsconfig.json",
+    "rescript.json",
     "src/**/*.res",
     "src/**/*.resi"
   ],


### PR DESCRIPTION
What it says on the tin; noticed it when I couldn't build after using a fork.