### PR TITLE
Get rid of %external usage

### DIFF
--- a/src/RescriptReactRouter.bs.js
+++ b/src/RescriptReactRouter.bs.js
@@ -5,6 +5,7 @@ var Curry = require("rescript/lib/js/curry.js");
 var React = require("react");
 var Js_array = require("rescript/lib/js/js_array.js");
 var Js_string = require("rescript/lib/js/js_string.js");
+var Caml_option = require("rescript/lib/js/caml_option.js");
 
 function safeMakeEvent(eventName) {
   if (typeof Event === "function") {
@@ -48,22 +49,22 @@ function pathParse(str) {
 }
 
 function path(serverUrlString, param) {
-  var match = typeof window === "undefined" ? undefined : window;
+  var match = globalThis.window;
   if (serverUrlString !== undefined) {
     return pathParse(serverUrlString);
   } else if (match !== undefined) {
-    return pathParse(match.location.pathname);
+    return pathParse(Caml_option.valFromOption(match).location.pathname);
   } else {
     return /* [] */0;
   }
 }
 
 function hash(param) {
-  var $$window = typeof window === "undefined" ? undefined : window;
+  var $$window = globalThis.window;
   if ($$window === undefined) {
     return "";
   }
-  var raw = $$window.location.hash;
+  var raw = Caml_option.valFromOption($$window).location.hash;
   switch (raw) {
     case "" :
     case "#" :
@@ -89,33 +90,33 @@ function searchParse(str) {
 }
 
 function search(serverUrlString, param) {
-  var match = typeof window === "undefined" ? undefined : window;
+  var match = globalThis.window;
   if (serverUrlString !== undefined) {
     return searchParse(serverUrlString);
   } else if (match !== undefined) {
-    return searchParse(match.location.search);
+    return searchParse(Caml_option.valFromOption(match).location.search);
   } else {
     return "";
   }
 }
 
 function push(path) {
-  var match = typeof history === "undefined" ? undefined : history;
-  var match$1 = typeof window === "undefined" ? undefined : window;
+  var match = globalThis.history;
+  var match$1 = globalThis.window;
   if (match !== undefined && match$1 !== undefined) {
-    match.pushState(null, "", path);
-    match$1.dispatchEvent(safeMakeEvent("popstate"));
+    Caml_option.valFromOption(match).pushState(null, "", path);
+    Caml_option.valFromOption(match$1).dispatchEvent(safeMakeEvent("popstate"));
     return ;
   }
   
 }
 
 function replace(path) {
-  var match = typeof history === "undefined" ? undefined : history;
-  var match$1 = typeof window === "undefined" ? undefined : window;
+  var match = globalThis.history;
+  var match$1 = globalThis.window;
   if (match !== undefined && match$1 !== undefined) {
-    match.replaceState(null, "", path);
-    match$1.dispatchEvent(safeMakeEvent("popstate"));
+    Caml_option.valFromOption(match).replaceState(null, "", path);
+    Caml_option.valFromOption(match$1).dispatchEvent(safeMakeEvent("popstate"));
     return ;
   }
   
@@ -159,7 +160,7 @@ function url(serverUrlString, param) {
 }
 
 function watchUrl(callback) {
-  var $$window = typeof window === "undefined" ? undefined : window;
+  var $$window = globalThis.window;
   if ($$window === undefined) {
     return function (param) {
       
@@ -168,14 +169,14 @@ function watchUrl(callback) {
   var watcherID = function (param) {
     Curry._1(callback, url(undefined, undefined));
   };
-  $$window.addEventListener("popstate", watcherID);
+  Caml_option.valFromOption($$window).addEventListener("popstate", watcherID);
   return watcherID;
 }
 
 function unwatchUrl(watcherID) {
-  var $$window = typeof window === "undefined" ? undefined : window;
+  var $$window = globalThis.window;
   if ($$window !== undefined) {
-    $$window.removeEventListener("popstate", watcherID);
+    Caml_option.valFromOption($$window).removeEventListener("popstate", watcherID);
     return ;
   }
   

--- a/src/RescriptReactRouter.res
+++ b/src/RescriptReactRouter.res
@@ -1,3 +1,9 @@
+@scope("globalThis")
+external window: option<Dom.window> = "window"
+
+@scope("globalThis")
+external history: option<Dom.history> = "history"
+
 @get external location: Dom.window => Dom.location = "location"
 
 /* actually the cb is Dom.event => unit, but let's restrict the access for now */
@@ -81,13 +87,13 @@ let pathParse = str =>
     raw |> Js.String.split("/") |> Js.Array.filter(item => String.length(item) != 0) |> arrayToList
   }
 let path = (~serverUrlString=?, ()) =>
-  switch (serverUrlString, %external(window)) {
+  switch (serverUrlString, window) {
   | (None, None) => list{}
   | (Some(serverUrlString), _) => pathParse(serverUrlString)
   | (_, Some(window: Dom.window)) => pathParse(window |> location |> pathname)
   }
 let hash = () =>
-  switch %external(window) {
+  switch window {
   | None => ""
   | Some(window: Dom.window) =>
     switch window |> location |> hash {
@@ -111,14 +117,14 @@ let searchParse = str =>
   }
 
 let search = (~serverUrlString=?, ()) =>
-  switch (serverUrlString, %external(window)) {
+  switch (serverUrlString, window) {
   | (None, None) => ""
   | (Some(serverUrlString), _) => searchParse(serverUrlString)
   | (_, Some(window: Dom.window)) => searchParse(window |> location |> search)
   }
 
 let push = path =>
-  switch (%external(history), %external(window)) {
+  switch (history, window) {
   | (None, _)
   | (_, None) => ()
   | (Some(history: Dom.history), Some(window: Dom.window)) =>
@@ -127,7 +133,7 @@ let push = path =>
   }
 
 let replace = path =>
-  switch (%external(history), %external(window)) {
+  switch (history, window) {
   | (None, _)
   | (_, None) => ()
   | (Some(history: Dom.history), Some(window: Dom.window)) =>
@@ -169,7 +175,7 @@ let url = (~serverUrlString=?, ()) => {
 let dangerouslyGetInitialUrl = url
 
 let watchUrl = callback =>
-  switch %external(window) {
+  switch window {
   | None => () => ()
   | Some(window: Dom.window) =>
     let watcherID = () => callback(url())
@@ -178,7 +184,7 @@ let watchUrl = callback =>
   }
 
 let unwatchUrl = watcherID =>
-  switch %external(window) {
+  switch window {
   | None => ()
   | Some(window: Dom.window) => removeEventListener(window, "popstate", watcherID)
   }


### PR DESCRIPTION
This fixes https://github.com/rescript-lang/rescript-compiler/issues/6905.

`%external` is weird and not typesafe and should probably be removed from the compiler.

Make use of `globalThis` instead. Downside: In older browsers, `globalThis` will need to be polyfilled. It is supported in all modern browsers though, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis.