### PR TITLE
Add external for basic support for formAction

### DIFF
--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -73,6 +73,8 @@ type formStatus<'state> = {
   action: React.action<'state, FormData.t>,
 }
 
+external formAction: React.formAction<FormData.t> => string = "%identity"
+
 /** `useFormStatus` is a Hook that gives you status information of the last form submission. */
 @module("react-dom")
 external useFormStatus: unit => formStatus<'state> = "useFormStatus"


### PR DESCRIPTION
not ideal, but seems to be the shortest, non-breaking path for now:

```rescript
<form action={ReactDOM.formAction(handler)}>
  // ...
</form>
```