### PR TITLE
Add `usePromise` for `use(promise)`

### DIFF
--- a/src/React.bs.js
+++ b/src/React.bs.js
@@ -23,8 +23,6 @@ function lazy_(load) {
 
 var Uncurried = {};
 
-var Usable = {};
-
 exports.Children = Children;
 exports.Context = Context;
 exports.Fragment = Fragment;
@@ -32,5 +30,4 @@ exports.StrictMode = StrictMode;
 exports.Suspense = Suspense;
 exports.lazy_ = lazy_;
 exports.Uncurried = Uncurried;
-exports.Usable = Usable;
 /* react Not a pure module */

--- a/src/React.res
+++ b/src/React.res
@@ -251,6 +251,9 @@ external useCallback7: ('callback, ('a, 'b, 'c, 'd, 'e, 'f, 'g)) => 'callback = 
 @module("react")
 external useContext: Context.t<'any> => 'any = "useContext"
 
+@module("react")
+external usePromise: promise<'a> => 'a = "use"
+
 @module("react") external useRef: 'value => ref<'value> = "useRef"
 
 @module("react")
@@ -432,17 +435,6 @@ external useActionState: (
 @module("react")
 external useOptimistic: ('state, ('state, 'action) => 'state) => ('state, 'action => unit) =
   "useOptimistic"
-
-module Usable = {
-  type t<'value>
-
-  external context: Context.t<'value> => t<'value> = "%identity"
-  external promise: promise<'value> => t<'value> = "%identity"
-}
-
-/** `use` is a React API that lets you read the value of a resource like a Promise or context. */
-@module("react")
-external use: Usable.t<'value> => 'value = "use"
 
 /** `act` is a test helper to apply pending React updates before making assertions. */
 @module("react")


### PR DESCRIPTION
`use(context)` seems to exactly replicate the `useContext(context)`
logic, and we want to maximize retro-compability (ie. not switch from
`useContext` to `use` for that under the hood).

simply adding `usePromise(promise)` seems to be the simplest, least
invasive way to add the functionality.
