### PR TITLE
useOptimistic optional updateFn

### DIFF
--- a/src/React.res
+++ b/src/React.res
@@ -433,8 +433,10 @@ external useActionState: (
 
 /** `useOptimistic` is a React Hook that lets you optimistically update the UI. */
 @module("react")
-external useOptimistic: ('state, ('state, 'action) => 'state) => ('state, 'action => unit) =
-  "useOptimistic"
+external useOptimistic: (
+  'state,
+  ~updateFn: ('state, 'action) => 'state=?,
+) => ('state, 'action => unit) = "useOptimistic"
 
 /** `act` is a test helper to apply pending React updates before making assertions. */
 @module("react")


### PR DESCRIPTION
`useOptimistic` updateFn is optional: https://github.com/facebook/react/blob/0db8db178c1521f979535bdba32bf9db9f47ca05/packages/react-reconciler/src/ReactInternalTypes.js#L441

And I use `updateFn` name from the doc: https://react.dev/reference/react/useOptimistic#use