### PR TITLE
fix useEffectEvent callback

### DIFF
--- a/src/React.res
+++ b/src/React.res
@@ -472,4 +472,4 @@ useEffectEvent is a React Hook that lets you extract non-reactive logic from you
 [Read more on the React Documentation](https://react.dev/reference/react/useEffectEvent)
 */
 @module("react")
-external useEffectEvent: (unit => unit) => unit = "useEffectEvent"
+external useEffectEvent: ('event => unit) => 'event => unit = "useEffectEvent"


### PR DESCRIPTION
Technically, this binding isn't exhaustive because the callback function could have more than one argument.

In practice, though, it's mostly used with callbacks that take zero or one argument.


To be fully exhaustive, we could also add:
```rescript
external unsafe_useEffectEvent: 'callback => 'callback = "useEffectEvent"
```
However, this is unsafe because `'callback` isn't constrained to a function type.