### PR TITLE
React 19 API fixes

### DIFF
--- a/src/React.res
+++ b/src/React.res
@@ -472,4 +472,4 @@ useEffectEvent is a React Hook that lets you extract non-reactive logic from you
 [Read more on the React Documentation](https://react.dev/reference/react/useEffectEvent)
 */
 @module("react")
-external useEffectEvent: ('event => unit) => 'event => unit = "useEffectEvent"
+external useEffectEvent: 'callback => 'callback = "useEffectEvent"

--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -91,7 +91,12 @@ module Ref = {
 
 // Hooks
 
-type formStatusAction = FormData.t => unit
+@unboxed
+type formStatusActionResult =
+  | @as(undefined) Sync
+  | Async(promise<unit>)
+
+type formStatusAction = FormData.t => formStatusActionResult
 
 type formStatus = {
   /** If true, this means the parent <form> is pending submission. Otherwise, false. */

--- a/src/ReactDOM.res
+++ b/src/ReactDOM.res
@@ -91,22 +91,24 @@ module Ref = {
 
 // Hooks
 
-type formStatus<'state> = {
+type formStatusAction = FormData.t => unit
+
+type formStatus = {
   /** If true, this means the parent <form> is pending submission. Otherwise, false. */
   pending: bool,
   /** An object implementing the FormData interface that contains the data the parent <form> is submitting. If there is no active submission or no parent <form>, it will be null. */
-  data: FormData.t,
+  data: nullable<FormData.t>,
   /** This represents whether the parent <form> is submitting with either a GET or POST HTTP method. By default, a <form> will use the GET method and can be specified by the method property. */
-  method: [#get | #post],
+  method: nullable<[#get | #post]>,
   /** A reference to the function passed to the action prop on the parent <form>. If there is no parent <form>, the property is null. If there is a URI value provided to the action prop, or no action prop specified, status.action will be null. */
-  action: React.action<'state, FormData.t>,
+  action: nullable<formStatusAction>,
 }
 
 external formAction: React.formAction<FormData.t> => string = "%identity"
 
 /** `useFormStatus` is a Hook that gives you status information of the last form submission. */
 @module("react-dom")
-external useFormStatus: unit => formStatus<'state> = "useFormStatus"
+external useFormStatus: unit => formStatus = "useFormStatus"
 
 // Resource Preloading APIs
 

--- a/src/ReactDOMServer.res
+++ b/src/ReactDOMServer.res
@@ -10,6 +10,18 @@ type resumeOptions<'error> = {
   onError?: 'error => unit,
 }
 
+type resumeToPipeableStreamOptions<'error> = {
+  ...resumeOptions<'error>,
+  onAllReady?: unit => unit,
+  onShellReady?: unit => unit,
+  onShellError?: 'error => unit,
+}
+
+type pipeableStream = {
+  pipe: ReactDOMStatic.nodeStream => ReactDOMStatic.nodeStream,
+  abort: unit => unit,
+}
+
 /**
 resume streams a pre-rendered React tree to a Readable Web Stream.
 [Read more on the React Documentation](https://react.dev/reference/react-dom/server/resume)
@@ -29,5 +41,5 @@ resumeToPipeableStream streams a pre-rendered React tree  to a pipeable Node.js 
 external resumeToPipeableStream: (
   React.element,
   ReactDOMStatic.postponedState,
-  ~options: resumeOptions<'error>=?,
-) => promise<ReactDOMStatic.nodeStream> = "resumeToPipeableStream"
+  ~options: resumeToPipeableStreamOptions<'error>=?,
+) => pipeableStream = "resumeToPipeableStream"


### PR DESCRIPTION
## Summary

Correct several React 19 and React 19.2 bindings so their ReScript types match the runtime APIs.

## Changes

### `useEffectEvent`

Preserve the callback’s complete type:

```rescript
external useEffectEvent: 'callback => 'callback
```

The previous binding only supported callbacks returning `unit` with at most one argument. React allows Effect Events to accept any number of arguments, return any value, and retain the original callback signature.

### `useFormStatus`

Align the returned status with React’s pending and non-pending states:

- Make `data` nullable when no form submission is active.
- Make `method` nullable because it is `null` in the non-pending state.
- Make `action` nullable when no function action is associated with the form.
- Model `action` as a one-argument `FormData` callback instead of a `useActionState` reducer.
- Remove the unused `'state` type parameter that resulted from the incorrect reducer type.

### `resumeToPipeableStream`

Correct the Node.js streaming API:

- Return the `{pipe, abort}` controller directly instead of a `Promise`.
- Add a dedicated `pipeableStream` type.
- Add the Node streaming lifecycle options:
  - `onAllReady`
  - `onShellReady`
  - `onShellError`
- Keep the shared `nonce`, `signal`, and `onError` options.

React returns this controller synchronously; the previous binding incorrectly described it as a promise resolving to a Node stream.